### PR TITLE
Support agent syntax

### DIFF
--- a/aiscript-vm/src/agent.rs
+++ b/aiscript-vm/src/agent.rs
@@ -1,0 +1,114 @@
+use std::collections::HashMap;
+
+use gc_arena::{Collect, Gc};
+
+use crate::{
+    ast::{Expr, LiteralValue},
+    string::InternedString,
+    vm::Context,
+};
+
+#[derive(Debug, Collect)]
+#[collect(no_drop)]
+pub struct Agent<'gc> {
+    pub name: InternedString<'gc>,
+    pub instructions: InternedString<'gc>,
+    pub model: InternedString<'gc>,
+    pub tools: Vec<InternedString<'gc>>,
+    pub tool_choice: ToolChoice,
+}
+
+// Controls which (if any) tool is called by the model.
+// none means the model will not call any tool and instead generates a message.
+// auto means the model can pick between generating a message or calling one or more tools.
+// required means the model must call one or more tools.
+// Specifying a particular tool via {"type": "function", "function": {"name": "my_function"}}
+// forces the model to call that tool.
+#[derive(Debug, Collect)]
+#[collect(no_drop)]
+pub enum ToolChoice {
+    None,
+    Auto,
+    Required,
+}
+
+impl<'gc> Agent<'gc> {
+    pub fn new(
+        ctx: &Context<'gc>,
+        name: InternedString<'gc>,
+        fields: &HashMap<InternedString<'gc>, Expr<'gc>>,
+    ) -> Agent<'gc> {
+        let mut instructions = InternedString::from_static(ctx, "test");
+        let mut model = InternedString::from_static(ctx, "gpt-4");
+        let mut tools = vec![];
+
+        for (key, expr) in fields {
+            match &*key.to_string() {
+                "instructions" => {
+                    instructions = match expr {
+                        Expr::Literal {
+                            value: LiteralValue::String(value),
+                            ..
+                        } => *value,
+                        _ => panic!("Expected string literal"),
+                    };
+                }
+                "model" => {
+                    model = match expr {
+                        Expr::Literal {
+                            value: LiteralValue::String(value),
+                            ..
+                        } => *value,
+                        _ => panic!("Expected string literal"),
+                    };
+                }
+                "tools" => {
+                    match expr {
+                        Expr::Array { elements, .. } => {
+                            for element in elements {
+                                match element {
+                                    Expr::Literal {
+                                        value: LiteralValue::String(value),
+                                        ..
+                                    } => {
+                                        tools.push(*value);
+                                    }
+                                    Expr::Variable { name, .. } => {
+                                        let name = ctx.intern(name.lexeme.as_bytes());
+                                        tools.push(name);
+                                    }
+                                    _ => panic!("Expected string literal"),
+                                }
+                            }
+                        }
+                        _ => panic!("Expected array"),
+                    };
+                }
+                _ => {}
+            }
+        }
+
+        Agent {
+            name,
+            instructions,
+            model,
+            tools,
+            tool_choice: ToolChoice::Auto,
+        }
+    }
+}
+
+pub fn run_agent<'gc>(agent: Gc<'gc, Agent<'gc>>, input: InternedString<'gc>) -> String {
+    format!(
+        "input: {},instructions: {}, model: {}, tools: {}",
+        input,
+        agent.instructions,
+        agent.model,
+        agent
+            .tools
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    )
+}

--- a/aiscript-vm/src/ast.rs
+++ b/aiscript-vm/src/ast.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::{lexer::Token, string::InternedString};
 
 #[derive(Debug, Clone)]
@@ -10,6 +12,10 @@ pub enum Expr<'gc> {
     },
     Grouping {
         expression: Box<Expr<'gc>>,
+        line: u32,
+    },
+    Array {
+        elements: Vec<Expr<'gc>>,
         line: u32,
     },
     Literal {
@@ -86,6 +92,7 @@ impl<'gc> Expr<'gc> {
         match self {
             Self::Binary { line, .. }
             | Self::Grouping { line, .. }
+            | Self::Array { line, .. }
             | Self::Literal { line, .. }
             | Self::Unary { line, .. }
             | Self::Variable { line, .. }
@@ -151,6 +158,11 @@ pub enum Stmt<'gc> {
         methods: Vec<Stmt<'gc>>,
         line: u32,
     },
+    Agent {
+        name: Token<'gc>,
+        fields: HashMap<InternedString<'gc>, Expr<'gc>>,
+        line: u32,
+    },
 }
 
 impl<'gc> Stmt<'gc> {
@@ -164,7 +176,8 @@ impl<'gc> Stmt<'gc> {
             | Self::Loop { line, .. }
             | Self::Function { line, .. }
             | Self::Return { line, .. }
-            | Self::Class { line, .. } => *line,
+            | Self::Class { line, .. }
+            | Self::Agent { line, .. } => *line,
         }
     }
 }

--- a/aiscript-vm/src/chunk.rs
+++ b/aiscript-vm/src/chunk.rs
@@ -50,6 +50,7 @@ pub enum OpCode {
     SuperInvoke(u8, u8),
     // AI
     Prompt,
+    Agent(u8), // constant index
 }
 
 impl OpCode {
@@ -223,6 +224,9 @@ impl<'gc> Chunk<'gc> {
                     self.invoke_instruction("SUPER_INVOKE", name, arity)
                 }
                 OpCode::Prompt => simple_instruction("PROMPT"),
+                OpCode::Agent(c) => {
+                    println!("{:-16} {:4} '{}'", "OP_AGENT", c, self.constans[c as usize]);
+                }
             }
         } else {
             println!("Invalid opcode at offset: {offset}");

--- a/aiscript-vm/src/lexer.rs
+++ b/aiscript-vm/src/lexer.rs
@@ -2,17 +2,20 @@ use std::{iter::Peekable, str::Chars};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TokenType {
-    OpenParen,  // (
-    CloseParen, // )
-    OpenBrace,  // {
-    CloseBrace, // }
-    Comma,      // ,
-    Dot,        // .
-    Minus,      // -
-    Plus,       // +
-    Semicolon,  // ;
-    Slash,      // /
-    Star,       // *
+    OpenParen,    // (
+    CloseParen,   // )
+    OpenBrace,    // {
+    CloseBrace,   // }
+    OpenBracket,  // [
+    CloseBracket, // ]
+    Comma,        // ,
+    Dot,          // .
+    Minus,        // -
+    Plus,         // +
+    Semicolon,    // ;
+    Slash,        // /
+    Star,         // *
+    Colon,        // :
 
     Bang,         // !
     BangEqual,    // !=
@@ -233,6 +236,8 @@ impl<'a> Scanner<'a> {
             match c {
                 '(' => return self.make_token(TokenType::OpenParen),
                 ')' => return self.make_token(TokenType::CloseParen),
+                '[' => return self.make_token(TokenType::OpenBracket),
+                ']' => return self.make_token(TokenType::CloseBracket),
                 '{' => return self.make_token(TokenType::OpenBrace),
                 '}' => return self.make_token(TokenType::CloseBrace),
                 ';' => return self.make_token(TokenType::Semicolon),
@@ -242,6 +247,7 @@ impl<'a> Scanner<'a> {
                 '+' => return self.make_token(TokenType::Plus),
                 '/' => return self.make_token(TokenType::Slash),
                 '*' => return self.make_token(TokenType::Star),
+                ':' => return self.make_token(TokenType::Colon),
                 '!' => {
                     return if self.peek2() == "!=" {
                         self.advance();

--- a/aiscript-vm/src/lib.rs
+++ b/aiscript-vm/src/lib.rs
@@ -1,3 +1,4 @@
+mod agent;
 mod ai;
 #[cfg(not(feature = "v1"))]
 mod ast;

--- a/aiscript-vm/src/pretty.rs
+++ b/aiscript-vm/src/pretty.rs
@@ -55,6 +55,13 @@ impl<'gc> fmt::Display for PrettyPrint<'_, Expr<'gc>> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let indent = self.indent();
         match self.value {
+            Expr::Array { elements, line } => {
+                writeln!(f, "{indent}Array [line {line}]")?;
+                for element in elements {
+                    write!(f, "{}", PrettyPrint::new(element, self.indent + 1))?;
+                }
+                Ok(())
+            }
             Expr::Binary {
                 left,
                 operator,
@@ -323,6 +330,12 @@ impl<'gc> fmt::Display for PrettyPrint<'_, Stmt<'gc>> {
                 for method in methods {
                     write!(f, "{}", PrettyPrint::new(method, self.indent + 2))?;
                 }
+                Ok(())
+            }
+            Stmt::Agent { name, line, .. } => {
+                writeln!(f, "{indent}Agent Statement [line {line}]")?;
+                writeln!(f, "{}Name: {:?}", "  ".repeat(self.indent + 1), name)?;
+                writeln!(f, "{}Fields:", "  ".repeat(self.indent + 1))?;
                 Ok(())
             }
         }

--- a/aiscript-vm/src/value.rs
+++ b/aiscript-vm/src/value.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 use gc_arena::{lock::GcRefLock, Collect, Gc};
 
 use crate::{
+    agent::Agent,
     object::{BoundMethod, Class, Closure, Function, Instance, NativeFn},
     string::InternedString,
     vm::VmError,
@@ -20,6 +21,7 @@ pub enum Value<'gc> {
     Class(GcRefLock<'gc, Class<'gc>>),
     Instance(GcRefLock<'gc, Instance<'gc>>),
     BoundMethod(Gc<'gc, BoundMethod<'gc>>),
+    Agent(Gc<'gc, Agent<'gc>>),
     Nil,
 }
 
@@ -72,6 +74,7 @@ impl<'gc> Display for Value<'gc> {
                 write!(f, "{}", s)
             }
             Value::BoundMethod(bm) => write!(f, "{}", bm.method.function),
+            Value::Agent(agent) => write!(f, "agent {}", agent.name),
             Value::Nil => write!(f, "nil"),
         }
     }
@@ -130,6 +133,13 @@ impl<'gc> Value<'gc> {
         match self {
             Value::Function(function) => Ok(function),
             _ => Err(VmError::RuntimeError("cannot convert to function.".into())),
+        }
+    }
+
+    pub fn as_agent(self) -> Result<Gc<'gc, Agent<'gc>>, VmError> {
+        match self {
+            Value::Agent(agent) => Ok(agent),
+            _ => Err(VmError::RuntimeError("cannot convert to agent.".into())),
         }
     }
 
@@ -248,6 +258,12 @@ impl<'gc> From<GcRefLock<'gc, Instance<'gc>>> for Value<'gc> {
 impl<'gc> From<Gc<'gc, BoundMethod<'gc>>> for Value<'gc> {
     fn from(value: Gc<'gc, BoundMethod<'gc>>) -> Self {
         Value::BoundMethod(value)
+    }
+}
+
+impl<'gc> From<Gc<'gc, Agent<'gc>>> for Value<'gc> {
+    fn from(value: Gc<'gc, Agent<'gc>>) -> Self {
+        Value::Agent(value)
     }
 }
 


### PR DESCRIPTION

```rs
/// Refund an item. Refund an item. Make sure you have the item_id of the form item_...
/// Ask for user confirmation before processing the refund.
fn process_refund(item_id) {
    print "[mock] Refunding item" + item_id;
    return "Success!";
}


/// Apply a discount to the user's cart.
fn apply_discount() {
    print "[mock] Applying discount...";
    return "Applied discount of 11%";
}

agent Triage {
    instructions: "Determine which agent is best suited to handle the user's request, and transfer the conversation to that agent.",
    model: "gpt-4",
    tools: [transfer_to_sales, transfer_to_refunds],
    tool_choice: "auto",
}

agent Sales {
    instructions: "Be super enthusiastic about selling bees.",
    tools: [transfer_back_to_triage],
}

agent Refund {
    instructions: "Help the user with a refund. If the reason is that it was too expensive, offer the user a refund code. If they insist, then process the refund.",
    tools: [transfer_back_to_triage, process_refund, apply_discount],
}

let triage_agent = agent.Triage();
let sales_agent = agent.Sales();
let refund_agent = agent.Refund();

/// Call this function if a user is asking about a topic that
/// is not handled by the current agent.
fn transfer_back_to_triage() {
    return triage_agent;
}

fn transfer_to_sales() {
    return sales_agent;
}

fn transfer_to_refunds() {
    return refunds_agent
}

let response = triage_agent.run("Hi");
```