### PR TITLE
Support validate path params in path block

### DIFF
--- a/aiscript-runtime/src/ast/mod.rs
+++ b/aiscript-runtime/src/ast/mod.rs
@@ -81,6 +81,7 @@ pub struct Endpoint {
     pub path_specs: Vec<PathSpec>,
     #[allow(unused)]
     pub return_type: Option<String>,
+    pub path: Vec<Field>,
     pub query: Vec<Field>,
     pub body: RequestBody,
     pub statements: String,

--- a/aiscript-runtime/src/lib.rs
+++ b/aiscript-runtime/src/lib.rs
@@ -210,6 +210,7 @@ async fn run_server(
         for endpoint_spec in route.endpoints {
             let endpoint = Endpoint {
                 annotation: endpoint_spec.annotation.or(&route.annotation),
+                path_params: endpoint_spec.path.into_iter().map(convert_field).collect(),
                 query_params: endpoint_spec.query.into_iter().map(convert_field).collect(),
                 body_type: endpoint_spec.body.kind,
                 body_fields: endpoint_spec

--- a/examples/routes/path.ai
+++ b/examples/routes/path.ai
@@ -1,0 +1,16 @@
+get /users/:id/posts/:postId {
+    path {
+        @string(min_len=3)
+        id: str,
+        postId: int,
+    }
+
+    query {
+        refresh: bool = true
+    }
+
+    print(path);
+    let userId = path.id;
+    let postId = path.postId;
+    return f"Accessing post {postId} for user {userId}";
+}


### PR DESCRIPTION
```js
get /users/:id/posts/:postId {
    path {
        @string(min_len=3)
        id: str,
        postId: int,
    }

    query {
        refresh: bool = true
    }

    print(path);
    let userId = path.id;
    let postId = path.postId;
    return f"Accessing post {postId} for user {userId}";
}
```