### PR TITLE
Fix the default capacity of USCC_BASE_CHARS in the format uscc

### DIFF
--- a/aiscript-directive/src/validator/format.rs
+++ b/aiscript-directive/src/validator/format.rs
@@ -54,7 +54,7 @@ mod uscc {
     });
 
     static USCC_BASE_CHARS: LazyLock<HashMap<char, u8>> = LazyLock::new(|| {
-        let mut base_chars = HashMap::with_capacity(17);
+        let mut base_chars = HashMap::with_capacity(31);
 
         [
             '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G',


### PR DESCRIPTION
The default capacity of USCC_BASE_CHARS in format uscc was mistakenly set to 17. Although this does not cause correctness bugs in the program, it may lead to unnecessary resizing of HashMap, impacting performance.